### PR TITLE
Update JSON response to follow rocket v4 patterns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rocket = "=0.5.0-rc.3"
+rocket = { version = "0.5.0-rc.3", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
-rocket_contrib = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,19 @@
 #[macro_use]
 extern crate rocket;
 
-use rocket::http::Status;
-use rocket_contrib::json::Json;
+use rocket::serde::json::Json;
 
 mod person;
 
 #[get("/")]
 fn index() -> Json<person::Person> {
-    Status::Ok;
     let p = person::Person {
         id: 1,
         first_name: "John".to_string(),
         last_name: "Doe".to_string(),
         age: 30,
     };
-    return Json(p);
+    Json(p)
 }
 
 #[launch]

--- a/src/person.rs
+++ b/src/person.rs
@@ -1,9 +1,4 @@
-use std::io::Cursor;
-
 use rocket::serde::Deserialize;
-use rocket::response::{self, Responder, Response};
-use rocket::http::ContentType;
-use rocket::Request;
 use serde::Serialize;
 
 #[derive(Serialize, Deserialize)]
@@ -16,27 +11,4 @@ pub struct Person {
     pub last_name: String,
     // age is the age of the person.
     pub age: u8,
-}
-
-impl Person {
-    // Create a new person.
-    pub fn new() -> Person {
-        Person {
-            id: 0,
-            first_name: "".to_string(),
-            last_name: "".to_string(),
-            age: 0,
-        }
-    }
-}
-
-impl<'r> Responder<'r> for Person {
-    fn respond_to(self, _: &Request) -> response::Result<'r> {
-        Response::build()
-            .sized_body(Cursor::new(format!("{}:{}", self.name, self.age)), None)
-            .raw_header("X-Person-Name", self.name)
-            .raw_header("X-Person-Age", self.age.to_string())
-            .header(ContentType::new("application", "x-person"))
-            .ok()
-    }
 }


### PR DESCRIPTION
Typical use of rocket_contrib (`v4`) does not fit with rocket v5. Existing rocket_contrib implements a rocket v4 Responder. rocket_v5 brings Json as a feature built in rather than an additional package which implements the correct Responder trait.

+ Move Json parsing to use rocket_v5's json feature
+ Remove unused imports (and rocket_contrib v4 package)
+ Remove unused implementations in `person.rs`

## Testing

### Running:
```
bash-5.1$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/rust-example-api`
🔧 Configured for debug.
   >> address: 127.0.0.1
   >> port: 8000
   >> workers: 8
   >> max blocking threads: 512
   >> ident: Rocket
   >> IP header: X-Real-IP
   >> limits: bytes = 8KiB, data-form = 2MiB, file = 1MiB, form = 32KiB, json = 1MiB, msgpack = 1MiB, string = 8KiB
   >> temp dir: /tmp
   >> http/2: true
   >> keep-alive: 5s
   >> tls: disabled
   >> shutdown: ctrlc = true, force = true, signals = [SIGTERM], grace = 2s, mercy = 3s
   >> log level: normal
   >> cli colors: true
📬 Routes:
   >> (index) GET /
📡 Fairings:
   >> Shield (liftoff, response, singleton)
🛡️ Shield:
   >> Permissions-Policy: interest-cohort=()
   >> X-Frame-Options: SAMEORIGIN
   >> X-Content-Type-Options: nosniff
🚀 Rocket has launched from http://127.0.0.1:8000
```

### Endpoint
```
curl localhost:8000
{"id":1,"first_name":"John","last_name":"Doe","age":30}
```
